### PR TITLE
[feature] add participant count to fast endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ user to participate in
 
 We are currently testing one endpoint:
 
-1. `http://localhost:8000/hub/fast/`: returns a dictionary with the name of fast plus the information for the church
-to which the fast belongs on a given date. The date is passed in as a query parameter, *e.g.*, to get the fast on
-March 29, 2024, append `?date=20240329` to the URL. If no date is passed, defaults to today. An invalid date string
-will return an empty fast.
+1. `http://localhost:8000/hub/fast/`: returns a dictionary with data for the logged-in user's fast on a given date.
+The date is passed in as a query parameter, *e.g.*, to get the fast on March 29, 2024, append `?date=20240329` to the 
+URL. If no date is passed, defaults to today. An invalid date string will return an empty fast. The dictionary should
+contain the following:
+    * the name of the fast
+    * the church to which the fast belongs
+    * the number of participants in the fast
 
 ## Contact Us!
 

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -25,6 +25,11 @@ class ChurchSerializer(serializers.ModelSerializer):
 
 class FastSerializer(serializers.ModelSerializer):
     church = ChurchSerializer()
+    participant_count = serializers.SerializerMethodField()
+
+    def get_participant_count(self, obj):
+        return obj.profiles.count()
+
     class Meta:
         model = models.Fast
-        fields = ["name", "church"]
+        fields = ["name", "church", "participant_count"]

--- a/hub/views.py
+++ b/hub/views.py
@@ -1,5 +1,6 @@
 """Views to perform actions upon API requests."""
 import datetime
+import json
 import logging
 
 from django.contrib.auth.models import Group, User
@@ -7,6 +8,18 @@ from rest_framework import permissions, response, views, viewsets
 
 from hub.models import Fast
 from hub import serializers
+
+
+def _get_fast_for_user_on_date(request):
+    user = request.user
+    date_str = request.query_params.get("date")
+    if date_str is None:
+        # get today by default
+        date = datetime.date.today()
+    else:
+        date = _parse_date_str(date_str)
+
+    return _get_user_fast_on_date(user, date)
 
 
 def _get_user_fast_on_date(user, date):
@@ -55,14 +68,5 @@ class FastOnDate(views.APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
-        user = request.user
-        date_str = request.query_params.get("date")
-        if date_str is None:
-            # get today by default
-            date = datetime.date.today()
-        else:
-            date = _parse_date_str(date_str)
-
-        fast = _get_user_fast_on_date(user, date)
-
+        fast = _get_fast_for_user_on_date(request)
         return response.Response(serializers.FastSerializer(fast).data)

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -31,5 +31,6 @@ def test_fast_on_date_endpoint(query_params, complete_fast_fixture, request):
         "name": complete_fast_fixture.name, 
         "church": {
             "name": church.name
-        }
+        },
+        "participant_count": complete_fast_fixture.profiles.count(),
     }


### PR DESCRIPTION
**Feature**

Modified existing fast endpoint to also return the "participant count," i.e., the number of people participating in the fast (including the user). Only required adding participant count to the FastSerializer and defining a method to count the number of participants in a fast.

**Additional Changes**

* Refactored retrieval of fast from request
* Updated README